### PR TITLE
Fix build_leaves bug that skips certain ways.

### DIFF
--- a/styles/default.json
+++ b/styles/default.json
@@ -16,7 +16,7 @@
         },
         "planet": {
             "type": "planet",
-            "tiles": ["info", "../tests/fixtures/nodes4/sort"],
+            "tiles": ["info", "../tests/fixtures/santacruz/sort"],
             "sprite": "https://storage.googleapis.com/hellopvt3/sprites",
             "minzoom": 0,
             "maxzoom": 12


### PR DESCRIPTION
Tracking the next tile with one way_tile_h variable is not enough. This is a reworking of the logic in build_leaves that solves the problem I was seeing with some ways in Southern California going missing.